### PR TITLE
Allow struct attrs with define!() macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argwerk"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["John-John Tedro <udoprog@tedro.se>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ use std::ffi::OsString;
 
 argwerk::define! {
     /// A command touring the capabilities of argwerk.
+    #[derive(Default)]
     #[usage = "tour [-h]"]
     struct Args {
         help: bool,

--- a/examples/define.rs
+++ b/examples/define.rs
@@ -1,0 +1,27 @@
+argwerk::define! {
+    /// A simple tool.
+    #[usage = "tool [-h]"]
+    struct Args {
+        help: bool,
+        limit: usize = 10,
+    }
+    /// The limit of the operation. (default: 10).
+    ["-l" | "--limit", int] => {
+        limit = str::parse(&int)?;
+    }
+    /// Print this help.
+    ["-h" | "--help"] => {
+        println!("{}", HELP);
+        help = true;
+    }
+}
+
+fn main() -> Result<(), argwerk::Error> {
+    let args = Args::args()?;
+    if args.help {
+        return Ok(());
+    }
+
+    dbg!(args);
+    Ok(())
+}

--- a/examples/tour.rs
+++ b/examples/tour.rs
@@ -2,6 +2,7 @@ use std::ffi::OsString;
 
 argwerk::define! {
     /// A command touring the capabilities of argwerk.
+    #[derive(Default)]
     #[usage = "tour [-h]"]
     struct Args {
         help: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@
 //!
 //! argwerk::define! {
 //!     /// A command touring the capabilities of argwerk.
+//!     #[derive(Default)]
 //!     #[usage = "tour [-h]"]
 //!     struct Args {
 //!         help: bool,
@@ -431,10 +432,14 @@ pub enum ErrorKind {
 /// declaration. This can be used to conveniently group and access data
 /// populated during argument parsing.
 ///
+/// You can use arbitrary attributes for the struct.
+/// Note that [`std::fmt::Debug`] will be automatically derived.
+///
 /// ```rust
 /// argwerk::define! {
 ///     /// A simple test command.
 ///     #[usage = "command [-h]"]
+///     #[derive(Default)]
 ///     struct Args {
 ///         help: bool,
 ///         limit: usize = 10,


### PR DESCRIPTION
This patch

* Adds a simple example using define.
* Adds a bunch of stuff to the define macro to allow arbitrary struct attributes.
* Updates the documentation to match.

Closes #6.

Note that this patch adds some extra externally visible utility macros beyond `__impl`. I judged that using the `@`-style implementation would be complicated and ugly and hard to maintain. If limiting visible macro API is strongly preferred, the patch could be reworked — though I'd prefer to be done, of course.